### PR TITLE
Update arduino-BerryIMU.ino

### DIFF
--- a/arduino-BerryIMU/arduino-BerryIMU.ino
+++ b/arduino-BerryIMU/arduino-BerryIMU.ino
@@ -53,20 +53,20 @@ void loop() {
 
   //Read the measurements from  sensors
   readACC(buff);
-  accRaw[0] = (int)(buff[0] | (buff[1] << 8));   
-  accRaw[1] = (int)(buff[2] | (buff[3] << 8));
-  accRaw[2] = (int)(buff[4] | (buff[5] << 8));
+  accRaw[0] = (short)(buff[0] | (buff[1] << 8));   
+  accRaw[1] = (short)(buff[2] | (buff[3] << 8));
+  accRaw[2] = (short)(buff[4] | (buff[5] << 8));
 
   readMAG(buff);
-  magRaw[0] = (int)(buff[0] | (buff[1] << 8));   
-  magRaw[1] = (int)(buff[2] | (buff[3] << 8));
-  magRaw[2] = (int)(buff[4] | (buff[5] << 8));
+  magRaw[0] = (short)(buff[0] | (buff[1] << 8));   
+  magRaw[1] = (short)(buff[2] | (buff[3] << 8));
+  magRaw[2] = (short)(buff[4] | (buff[5] << 8));
 
 
   readGYR(buff);
-  gyrRaw[0] = (int)(buff[0] | (buff[1] << 8));   
-  gyrRaw[1] = (int)(buff[2] | (buff[3] << 8));
-  gyrRaw[2] = (int)(buff[4] | (buff[5] << 8));
+  gyrRaw[0] = (short)(buff[0] | (buff[1] << 8));   
+  gyrRaw[1] = (short)(buff[2] | (buff[3] << 8));
+  gyrRaw[2] = (short)(buff[4] | (buff[5] << 8));
 
   //Convert Gyro raw to degrees per second
   rate_gyr_x = (float) gyrRaw[0] * G_GAIN;


### PR DESCRIPTION
Changing the 16 bits of raw reading results to type 'short' (int16), rather than type 'int' (int32). Casting a 2-byte value to the 4-byte 'int' fails to propagate the sign bit, which means all of the *Raw values show up as unsigned 16-bit integers (0 to +65535), instead of signed values (-32768 to +32767).

The most noticeable result is that the angle of the heading always shows up in the first quadrant, i.e. between 0 and 90 degrees.

Casting the 2-byte composite value to a 'short' yields the desired sign value, and when it is assigned to an 'int' variable, the sign is preserved.